### PR TITLE
add standalone plugin runner, printing output in Mermaid format

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/catalog/cmd/catalog/config.go
+++ b/catalog/cmd/catalog/config.go
@@ -16,10 +16,9 @@ type config struct {
 }
 
 type envConfig struct {
-	Port        int                      `env:"PORT" default:"8090"`
-	HTTPTimeout time.Duration            `env:"HTTP_TIMEOUT" default:"5s"`
-	MLflow      plugins.MLflowEnvConfig  `env:"MLFLOW_"`
-	LiteLLM     plugins.LiteLLMEnvConfig `env:"LITELLM_"`
+	Port        int           `env:"PORT" default:"8090"`
+	HTTPTimeout time.Duration `env:"HTTP_TIMEOUT" default:"5s"`
+	Plugins     plugins.Config
 }
 
 func loadConfig() (config, error) {
@@ -28,11 +27,9 @@ func loadConfig() (config, error) {
 		return config{}, fmt.Errorf("load config from environment: %w", err)
 	}
 
-	cfg := config{
+	return config{
 		Port:        raw.Port,
 		HTTPTimeout: raw.HTTPTimeout,
-		Plugins:     plugins.LoadConfig(raw.MLflow, raw.LiteLLM),
-	}
-
-	return cfg, nil
+		Plugins:     raw.Plugins,
+	}, nil
 }

--- a/catalog/cmd/plugintest/main.go
+++ b/catalog/cmd/plugintest/main.go
@@ -1,0 +1,102 @@
+// Plugintest runs a selected plugin standalone, printing its results to stdout
+// in Mermaid graph format.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"reflect"
+	"strings"
+
+	"go-simpler.org/env"
+
+	"github.com/naira-project/naira/catalog/internal/plugins"
+	"github.com/naira-project/naira/catalog/pluginapi"
+)
+
+func main() {
+	selectedName := ""
+	if len(os.Args) > 2 {
+		fmt.Fprintf(os.Stderr, "usage: %s <plugin-name>\n", os.Args[0])
+		os.Exit(1)
+	}
+	if len(os.Args) == 2 {
+		selectedName = os.Args[1]
+	}
+	// if no args provided, we'll want to still print the list of available plugins
+
+	var cfg plugins.Config
+	if err := env.Load(&cfg, &env.Options{SliceSep: ","}); err != nil {
+		fmt.Fprintf(os.Stderr, "error: loading config: %v\n", err)
+		os.Exit(1)
+	}
+	forceEnablePlugins(&cfg)
+	registered := plugins.Register(cfg, &http.Client{}, log.New(os.Stderr, "", 0))
+
+	pluginsByName := make(map[string]pluginapi.Plugin, len(registered))
+	pluginNames := make([]string, 0, len(registered))
+	for _, p := range registered {
+		pluginsByName[p.Name()] = p
+		pluginNames = append(pluginNames, p.Name())
+	}
+
+	if selectedName == "" {
+		fmt.Fprintf(os.Stderr, "usage: %s <plugin-name>\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "no plugin specified; enabled plugins: %s\n", strings.Join(pluginNames, ", "))
+		os.Exit(1)
+	}
+	plugin := pluginsByName[selectedName]
+	if plugin == nil {
+		fmt.Fprintf(os.Stderr, "error: plugin %q not found; enabled plugins: %s\n", selectedName, strings.Join(pluginNames, ", "))
+		os.Exit(1)
+	}
+
+	result, err := plugin.Collect(context.Background())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error running plugin: %v\n", err)
+		os.Exit(1)
+	}
+
+	printMermaid(result)
+}
+
+// forceEnablePlugins sets Enabled=true on every sub-struct in cfg that has a
+// bool field named "Enabled".
+func forceEnablePlugins(cfg *plugins.Config) {
+	v := reflect.ValueOf(cfg).Elem()
+	for i := range v.NumField() {
+		f := v.Field(i)
+		if f.Kind() != reflect.Struct {
+			continue
+		}
+		enabled := f.FieldByName("Enabled")
+		if enabled.IsValid() && enabled.Kind() == reflect.Bool {
+			enabled.SetBool(true)
+		}
+	}
+}
+
+func printMermaid(req pluginapi.IngestionRequest) {
+	fmt.Println("graph TD")
+
+	ids := make(map[pluginapi.NodeID]string, len(req.Nodes))
+	for i, node := range req.Nodes {
+		mermaidID := fmt.Sprintf("n%d", i)
+		ids[node.ID] = mermaidID
+		label := node.ID.Kind + "/" + node.ID.Path
+		fmt.Printf("    %s[\"%s\"]\n", mermaidID, label)
+	}
+
+	for _, rel := range req.Relations {
+		from, fromOK := ids[rel.From]
+		to, toOK := ids[rel.To]
+		if !fromOK || !toOK {
+			fmt.Fprintf(os.Stderr, "WARN: relation's node(s) not predeclared: %v\n", rel)
+			continue
+		}
+		fmt.Printf("    %s -->|\"%s\"| %s\n", from, rel.Kind, to)
+	}
+}

--- a/catalog/cmd/plugintest/main.go
+++ b/catalog/cmd/plugintest/main.go
@@ -29,7 +29,7 @@ func main() {
 	// if no args provided, we'll want to still print the list of available plugins
 
 	var cfg plugins.Config
-	if err := env.Load(&cfg, &env.Options{SliceSep: ","}); err != nil {
+	if err := env.Load(&cfg, nil); err != nil {
 		fmt.Fprintf(os.Stderr, "error: loading config: %v\n", err)
 		os.Exit(1)
 	}

--- a/catalog/cmd/plugintest/main.go
+++ b/catalog/cmd/plugintest/main.go
@@ -67,8 +67,7 @@ func main() {
 // bool field named "Enabled".
 func forceEnablePlugins(cfg *plugins.Config) {
 	v := reflect.ValueOf(cfg).Elem()
-	for i := range v.NumField() {
-		f := v.Field(i)
+	for _, f := range v.Fields() {
 		if f.Kind() != reflect.Struct {
 			continue
 		}

--- a/catalog/internal/plugins/config.go
+++ b/catalog/internal/plugins/config.go
@@ -1,40 +1,11 @@
 package plugins
 
 import (
-	"strings"
-
 	"github.com/naira-project/naira/catalog/internal/plugins/litellm"
 	"github.com/naira-project/naira/catalog/internal/plugins/mlflow"
 )
 
 type Config struct {
-	MLflow  mlflow.Config
-	LiteLLM litellm.Config
-}
-
-type MLflowEnvConfig struct {
-	Enabled     bool   `env:"ENABLED" default:"true"`
-	BaseURL     string `env:"BASE_URL" default:"http://127.0.0.1:5000"`
-	BearerToken string `env:"BEARER_TOKEN"`
-}
-
-type LiteLLMEnvConfig struct {
-	Enabled bool   `env:"ENABLED" default:"true"`
-	BaseURL string `env:"BASE_URL" default:"http://127.0.0.1:4000"`
-	APIKey  string `env:"API_KEY"`
-}
-
-func LoadConfig(mlflowConfig MLflowEnvConfig, litellmConfig LiteLLMEnvConfig) Config {
-	return Config{
-		MLflow: mlflow.Config{
-			Enabled:     mlflowConfig.Enabled,
-			BaseURL:     strings.TrimSpace(mlflowConfig.BaseURL),
-			BearerToken: strings.TrimSpace(mlflowConfig.BearerToken),
-		},
-		LiteLLM: litellm.Config{
-			Enabled: litellmConfig.Enabled,
-			BaseURL: strings.TrimSpace(litellmConfig.BaseURL),
-			APIKey:  strings.TrimSpace(litellmConfig.APIKey),
-		},
-	}
+	MLflow  mlflow.Config  `env:"MLFLOW_"`
+	LiteLLM litellm.Config `env:"LITELLM_"`
 }

--- a/catalog/internal/plugins/litellm/plugin.go
+++ b/catalog/internal/plugins/litellm/plugin.go
@@ -34,9 +34,9 @@ type Plugin struct {
 }
 
 type Config struct {
-	Enabled bool
-	BaseURL string
-	APIKey  string
+	Enabled bool   `env:"ENABLED" default:"true"`
+	BaseURL string `env:"BASE_URL" default:"http://127.0.0.1:4000"`
+	APIKey  string `env:"API_KEY"`
 }
 
 func New(httpClient *http.Client, logger *log.Logger, config Config) *Plugin {

--- a/catalog/internal/plugins/mlflow/plugin.go
+++ b/catalog/internal/plugins/mlflow/plugin.go
@@ -27,9 +27,9 @@ type Plugin struct {
 }
 
 type Config struct {
-	Enabled     bool
-	BaseURL     string
-	BearerToken string
+	Enabled     bool   `env:"ENABLED" default:"true"`
+	BaseURL     string `env:"BASE_URL" default:"http://127.0.0.1:5000"`
+	BearerToken string `env:"BEARER_TOKEN"`
 }
 
 func New(httpClient *http.Client, config Config) *Plugin {


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? Please link the related Issues-->

Add `cmd/plugintest` - a helper for running & debugging a single plugin by name, printing its
output in Mermaid graph format.

Also, refactor config loading - reduce complexity layers and make it easier to add new plugins in the future.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [x] 🔧 Refactoring (no functional changes)
- [ ] 🏗️ Infrastructure / CI / Helm

## How Has This Been Tested?

<!-- Describe the tests that you ran. Need update when project progresses -->

- [x] `go test ./...` passes
- [ ] `helm lint` passes
- [ ] Manual testing via Docker Compose
- [x] Manual testing on Kubernetes

## Checklist

- [ ] My code follows the project's coding standards ([AGENTS.md](AGENTS.md))
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally
- [ ] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings

## AI Usage

Initial code and refactoring done with Claude Code (sonnet-4.6). Some changes and refactoring done by hand afterwards.


## Screenshots (if applicable)

Example diagram generated by an experimental WIP plugin (not included):

```mermaid
graph TD
    n0["git_repository/flux-system/flux-system"]
    n1["Kustomization.fluxcd/flux-system/flux-system"]
    n2["deployment/default/chat"]
    n3["deployment/default/chat2"]
    n4["deployment/default/hello-world"]
    n5["deployment/default/ollama"]
    n1 -->|"sourced_from"| n0
    n1 -->|"describes"| n2
    n2 -->|"deployed_from"| n0
    n1 -->|"describes"| n3
    n3 -->|"deployed_from"| n0
    n1 -->|"describes"| n4
    n4 -->|"deployed_from"| n0
    n1 -->|"describes"| n5
    n5 -->|"deployed_from"| n0
```
