### PR TITLE
Feat: mise config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,25 @@ Naira helps teams:
 
 Built with and for the cloud-native ecosystem, Naira is designed to integrate closely with technologies such as **PlatformMesh**, **OpenMFP/Luigi**, **KCP**, and other components of the NeoNephos stack.
 
+## Getting Started
+
+### Prerequisites
+
+This project requires several local tools (such as `kind`, `task`,`go`). 
+
+**The Recommended Way (Using mise):**
+We use [mise](https://mise.jdx.dev/) to manage tools automatically. If you have `mise` installed, simply run:
+```bash
+mise install
+```
+Alternative Way (Manual Installation):
+If you prefer not to use mise, you can find the exact versions of all tools in the mise.toml file.
+
+### Local Development
+To spin up the environment and access the services locally, follow these steps:
+- `task platform:deploy` - deploys the platform to kind
+- `task forward:all` - port-forward the main developer-facing services
+
 ## Support, Feedback, Contributing
 
 This project is open to feature requests/suggestions, bug reports etc. via [GitHub issues](https://github.com/naira-project/<your-project>/issues). Contribution and feedback are encouraged and always welcome. For more information about how to contribute, the project structure, as well as additional contribution information, see our [Contribution Guidelines](CONTRIBUTING.md).

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -5,6 +5,8 @@ vars:
   CATALOG_DIR: ./catalog
 
 tasks:
+  # Tool versions are managed via mise (https://mise.jdx.dev).
+  # See mise.toml in the repo root.
   check:
     desc: Verify required local tools exist
     cmds:

--- a/deploy/dev/infra/kind/kind-config.yaml
+++ b/deploy/dev/infra/kind/kind-config.yaml
@@ -4,3 +4,4 @@ name: naira-idp
 
 nodes:
   - role: control-plane
+    image: kindest/node:v1.36.1 # update kubectl in mise.toml if changing version 

--- a/mise.toml
+++ b/mise.toml
@@ -1,8 +1,9 @@
 [tools]
-go = "1.26"
-python = "3.11"
-kind = "0.32"
-kubectl = "1.36"
-helm = "4.2"
 buf = "1.71"
+go = "1.26"
 task = "3.51"
+# deploy/
+helm = "4.2"
+kubectl = "1.36" # update kind in kind-config.yaml if changing version 
+kind = "0.32"
+python = "3.11"

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,8 @@
+[tools]
+go = "1.26"
+python = "3.11"
+kind = "0.32"
+kubectl = "1.36"
+helm = "4.2"
+buf = "1.71"
+task = "3.51"


### PR DESCRIPTION
## Description

Adding mise config file. Useful for ensuring that contributors have the same versions of tools installed
In addition I pinned version of k8s cluster, so it can match kubectl version

ticket https://github.com/naira-project/naira/issues/77