### PR TITLE
fix: openmetadata plugin fix - port value change & remove ns creation from secrets file

### DIFF
--- a/deploy/dev/Taskfile.yml
+++ b/deploy/dev/Taskfile.yml
@@ -201,6 +201,7 @@ tasks:
     cmds:
       - helm repo add {{.OPENMETADATA_HELM_REPO_NAME}} {{.OPENMETADATA_HELM_REPO_URL}} --force-update
       - helm repo update {{.OPENMETADATA_HELM_REPO_NAME}}
+      - kubectl create namespace {{.OPENMETADATA_NAMESPACE}} --dry-run=client -o yaml | kubectl apply -f -
       - kubectl apply -f {{.OPENMETADATA_SECRETS_MANIFEST}}
       - helm upgrade --install {{.OPENMETADATA_DEPS_RELEASE}} {{.OPENMETADATA_DEPS_CHART}} --namespace {{.OPENMETADATA_NAMESPACE}} --create-namespace --values {{.OPENMETADATA_DEPS_VALUES}} --wait --timeout 15m
       - helm upgrade --install {{.OPENMETADATA_RELEASE}} {{.OPENMETADATA_CHART}} --namespace {{.OPENMETADATA_NAMESPACE}} --values {{.OPENMETADATA_VALUES}} --wait --timeout 15m
@@ -219,6 +220,7 @@ tasks:
           helm uninstall {{.OPENMETADATA_DEPS_RELEASE}} -n {{.OPENMETADATA_NAMESPACE}}
         fi
       - kubectl delete -f {{.OPENMETADATA_SECRETS_MANIFEST}} --ignore-not-found
+      - kubectl delete namespace {{.OPENMETADATA_NAMESPACE}} --ignore-not-found
 
   openmetadata:port-forward:
     desc: Expose OpenMetadata on localhost:8585

--- a/deploy/dev/infra/kubernetes/catalog.yaml
+++ b/deploy/dev/infra/kubernetes/catalog.yaml
@@ -230,7 +230,7 @@ spec:
           imagePullPolicy: IfNotPresent
           env:
             - name: PORT
-              value: "50055"
+              value: "50056"
             - name: OPENMETADATA_BASE_URL
               value: http://openmetadata.openmetadata.svc.cluster.local:8585
             - name: OPENMETADATA_ADMIN_EMAIL

--- a/deploy/dev/infra/kubernetes/openmetadata-secrets.yaml
+++ b/deploy/dev/infra/kubernetes/openmetadata-secrets.yaml
@@ -1,10 +1,5 @@
 # https://docs.open-metadata.org/v1.12.x/quick-start/local-kubernetes-deployment
-# Create the namespace and the kubernetes secrets that contain the MySQL and Airflow passwords.
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: openmetadata
----
+# Create kubernetes secrets that contains MySQL and Airflow passwords as secrets.
 apiVersion: v1
 kind: Secret
 metadata:

--- a/plugins/cmd/openmetadata/Dockerfile
+++ b/plugins/cmd/openmetadata/Dockerfile
@@ -19,7 +19,7 @@ FROM gcr.io/distroless/static-debian12:latest
 
 COPY --from=builder /out/plugin /plugin
 
-EXPOSE 50055
+EXPOSE 50051
 
 USER nonroot:nonroot
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? Please link the related Issues-->

Fixes wrong openmetadata port
Moves ns creation away from openmetadata-secrets file according to this comment I missed on last PR https://github.com/naira-project/naira/pull/93#discussion_r3586300884 

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [x] 🔧 Refactoring (no functional changes)
- [ ] 🏗️ Infrastructure / CI / Helm

## How Has This Been Tested?

<!-- Describe the tests that you ran. Need update when project progresses -->

- [ ] `go test ./...` passes
- [ ] `helm lint` passes
- [ ] Manual testing via Docker Compose
- [ ] Manual testing on Kubernetes

## Checklist

- [ ] My code follows the project's coding standards ([AGENTS.md](AGENTS.md))
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally
- [ ] I have updated the documentation (if applicable)
- [ ] My changes generate no new warnings

<!-- Uncomment when AI was used for this PR
 Describe how and for what AI was used in this PR
## AI Usage



-->
<!-- Add screenshots for UI changes.

## Screenshots (if applicable)
-->
