### PR TITLE
feat: add -neo4j graph formatting flag for plugins

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.0
 require (
 	github.com/go-chi/chi/v5 v5.3.0
 	github.com/google/uuid v1.6.0
+	github.com/neo4j/neo4j-go-driver/v5 v5.28.4
 	github.com/stretchr/testify v1.11.1
 	go-simpler.org/env v0.12.0
 	google.golang.org/grpc v1.81.1
@@ -23,7 +24,6 @@ require (
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFd
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/neo4j/neo4j-go-driver/v5 v5.28.4 h1:7toxehVcYkZbyxV4W3Ib9VcnyRBQPucF+VwNNmtSXi4=
+github.com/neo4j/neo4j-go-driver/v5 v5.28.4/go.mod h1:Vff8OwT7QpLm7L2yYr85XNWe9Rbqlbeb9asNXJTHO4k=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/plugins/pkg/pluginmain/neo4j.go
+++ b/plugins/pkg/pluginmain/neo4j.go
@@ -1,0 +1,147 @@
+package pluginmain
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/naira-project/naira/plugins/pkg/pluginapi"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
+)
+
+func printNeo4j(req pluginapi.CollectResponse, prefix string, logger *log.Logger) {
+	declared := make(map[pluginapi.NodeID]bool, len(req.Nodes))
+
+	for _, node := range req.Nodes {
+		declared[node.ID] = true
+		setClause := propsToNeo4jSetClause(prefix, "n", node.Properties, func(_ int, value string) string {
+			return neo4jCypherString(value)
+		})
+		fmt.Printf("MERGE (n:`%s` {path: %s})%s;\n",
+			node.ID.Kind,
+			neo4jCypherString(node.ID.Path),
+			setClause)
+	}
+
+	fmt.Println()
+
+	for _, rel := range req.Relations {
+		if !declared[rel.From] || !declared[rel.To] {
+			logger.Printf("WARN: relation's node(s) not predeclared: %v", rel)
+			continue
+		}
+
+		fmt.Printf("MATCH (a:`%s` {path: %s}), (b:`%s` {path: %s})\n",
+			rel.From.Kind, neo4jCypherString(rel.From.Path),
+			rel.To.Kind, neo4jCypherString(rel.To.Path))
+
+		setClause := propsToNeo4jSetClause(prefix, "r", rel.Properties, func(_ int, value string) string {
+			return neo4jCypherString(value)
+		})
+		fmt.Printf("MERGE (a)-[r:`%s`]->(b)%s;\n\n", rel.Kind, setClause)
+	}
+}
+
+func pushNeo4j(ctx context.Context, req pluginapi.CollectResponse, prefix, url string, logger *log.Logger) error {
+	username := os.Getenv("NEO4J_USERNAME")
+	if username == "" {
+		username = "neo4j"
+	}
+	password := os.Getenv("NEO4J_PASSWORD")
+
+	driver, err := neo4j.NewDriverWithContext(url, neo4j.BasicAuth(username, password, ""))
+	if err != nil {
+		return fmt.Errorf("creating neo4j driver: %w", err)
+	}
+	defer driver.Close(ctx)
+
+	session := driver.NewSession(ctx, neo4j.SessionConfig{})
+	defer session.Close(ctx)
+
+	_, err = session.ExecuteWrite(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
+		for _, node := range req.Nodes {
+			params := map[string]any{"path": node.ID.Path}
+
+			setClause := propsToNeo4jSetClause(prefix, "n", node.Properties, func(i int, value string) string {
+				param := fmt.Sprintf("p%d", i)
+				params[param] = value
+				return "$" + param
+			})
+
+			query := fmt.Sprintf("MERGE (n:`%s` {path: $path})%s",
+				node.ID.Kind, setClause)
+
+			result, err := tx.Run(ctx, query, params)
+			if err != nil {
+				return nil, fmt.Errorf("merging node %v: %w", node.ID, err)
+			}
+			if _, err := result.Consume(ctx); err != nil {
+				return nil, fmt.Errorf("consuming node result %v: %w", node.ID, err)
+			}
+		}
+
+		for _, rel := range req.Relations {
+			params := map[string]any{
+				"fromPath": rel.From.Path,
+				"toPath":   rel.To.Path,
+			}
+
+			setClause := propsToNeo4jSetClause(prefix, "r", rel.Properties, func(i int, value string) string {
+				param := fmt.Sprintf("p%d", i)
+				params[param] = value
+				return "$" + param
+			})
+
+			query := fmt.Sprintf(
+				"MATCH (a:`%s` {path: $fromPath}), (b:`%s` {path: $toPath}) MERGE (a)-[r:`%s`]->(b)%s",
+				rel.From.Kind, rel.To.Kind, rel.Kind, setClause)
+
+			result, err := tx.Run(ctx, query, params)
+			if err != nil {
+				return nil, fmt.Errorf("merging relation %v->%v: %w", rel.From, rel.To, err)
+			}
+			if _, err := result.Consume(ctx); err != nil {
+				return nil, fmt.Errorf("consuming relation result %v->%v: %w", rel.From, rel.To, err)
+			}
+		}
+
+		return nil, nil
+	})
+	if err != nil {
+		return fmt.Errorf("executing write transaction: %w", err)
+	}
+	return nil
+}
+
+// propsToNeo4jSetClause builds a " SET varName.`prefix.key` = <value>, ..." clause, or "" if props is empty.
+// valueFn renders the right-hand <value> side of each assignment (e.g. a literal or a query parameter).
+func propsToNeo4jSetClause(prefix, varName string, props pluginapi.PropertyMap, valueFn func(i int, value string) string) string {
+	keys := sortedKeys(props)
+	if len(keys) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(keys))
+	for i, k := range keys {
+		parts = append(parts, fmt.Sprintf("%s.`%s.%s` = %s", varName, prefix, k, valueFn(i, props[k])))
+	}
+	return " SET " + strings.Join(parts, ", ")
+}
+
+// neo4jCypherString escapes s for use as a Cypher double-quoted string literal.
+func neo4jCypherString(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	return `"` + s + `"`
+}
+
+func sortedKeys(m pluginapi.PropertyMap) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/plugins/pkg/pluginmain/pluginmain.go
+++ b/plugins/pkg/pluginmain/pluginmain.go
@@ -47,7 +47,11 @@ func New[C any]() *App[C] {
 }
 
 func (a *App[C]) Serve(p pluginapi.Plugin) {
-	mermaidFlag := flag.Bool("mermaid", false, "Return the collect result in Mermaid format and terminate")
+	var (
+		mermaidFlag = flag.Bool("mermaid", false, "Return the collect result in Mermaid format and terminate")
+		neo4jPrefix = flag.String("neo4j", "", "Return the collect result as Neo4j Cypher with the given property prefix and terminate")
+		neo4jURL    = flag.String("neo4j-url", "", "Push the collect result to the given Neo4j URL instead of printing (requires -neo4j)")
+	)
 	flag.Parse()
 
 	if *mermaidFlag {
@@ -56,6 +60,21 @@ func (a *App[C]) Serve(p pluginapi.Plugin) {
 			a.Logger.Fatalf("failed to collect: %v", err)
 		}
 		printMermaid(res, a.Logger)
+		return
+	}
+
+	if *neo4jPrefix != "" {
+		res, err := p.Collect(context.Background())
+		if err != nil {
+			a.Logger.Fatalf("failed to collect: %v", err)
+		}
+		if *neo4jURL == "" {
+			printNeo4j(res, *neo4jPrefix, a.Logger)
+			return
+		}
+		if err := pushNeo4j(context.Background(), res, *neo4jPrefix, *neo4jURL, a.Logger); err != nil {
+			a.Logger.Fatalf("failed to push to neo4j: %v", err)
+		}
 		return
 	}
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? Please link the related Issues-->

Adds two flags to plugins (via pluginmain):

- `-neo4j PREFIX` - makes a plugin print a graph in Neo4j graph DB's "Cypher" syntax, rather than running the plugin as a service (similar to preexisting `-mermaid` flag, but in a different format);
- `-neo4j-url bolt://NEO4J_HOST:7687` - when used with `-neo4j` flag, makes the plugin push the data into the provided Neo4j host instead of just printing them on stdout.

This closes #81 .


## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] 🏗️ Infrastructure / CI / Helm

## How Has This Been Tested?

<!-- Describe the tests that you ran. Need update when project progresses -->

- [x] `go test ./...` passes
- [ ] `helm lint` passes
- [ ] Manual testing via Docker Compose
- [x] Manual testing on Kubernetes

## Checklist

- [ ] My code follows the project's coding standards ([AGENTS.md](AGENTS.md))
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally
- [ ] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings

## AI Usage

Claude sonnet 4.6, then 5.0, with various manual tweaks on top.


## Screenshots (if applicable)

Example screenshot from Neo4j after running three plugins over some sample cluster:

<img width="303" height="487" alt="Screenshot 2026-08-05 at 17 04 48" src="https://github.com/user-attachments/assets/268467eb-be90-4c74-a8e7-3afafc48cd28" />
