### PR TITLE
fix: decode path segments in GetNode

### DIFF
--- a/catalog/internal/httpapi/nodes.go
+++ b/catalog/internal/httpapi/nodes.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 
 	"github.com/go-chi/chi/v5"
 
@@ -96,7 +97,15 @@ func newListNodesHandler(service *catalog.Service, logger *log.Logger) http.Hand
 // GET /v1/nodes/{kind}/* returns a single catalog node.
 func newGetNodeHandler(service *catalog.Service) http.HandlerFunc {
 	return handle(func(w http.ResponseWriter, r *http.Request) error {
-		node, err := service.GetNode(r.Context(), catalog.NodeID{Kind: chi.URLParam(r, "kind"), Path: chi.URLParam(r, "*")})
+		path, err := url.PathUnescape(chi.URLParam(r, "*"))
+		if err != nil {
+			return fmt.Errorf("unescaping node path: %w", err)
+		}
+
+		node, err := service.GetNode(r.Context(), catalog.NodeID{
+			Kind: chi.URLParam(r, "kind"),
+			Path: path,
+		})
 		if err != nil {
 			return fmt.Errorf("getting node: %w", err)
 		}

--- a/catalog/internal/httpapi/router_test.go
+++ b/catalog/internal/httpapi/router_test.go
@@ -260,6 +260,33 @@ func TestRouterServesCurrentEndpoints(t *testing.T) {
 	}
 }
 
+func TestGetNodeDecodesEscapedPathSegments(t *testing.T) {
+	store := catalog.NewMemoryStore()
+	applyPluginSnapshot(t, store, []catalog.NodeClaim{{
+		ID: catalog.NodeID{Kind: "owner", Path: "@naira-project/dev"},
+	}}, nil)
+
+	router := newTestRouter(store, operations.NewMemoryStore(), nil)
+	req := httptest.NewRequest(http.MethodGet, "/v1/nodes/owner/%40naira-project/dev", nil)
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	var response Node
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
+	assert.Equal(t, Node{
+		Name: "nodes/owner/@naira-project/dev",
+		Kind: "owner",
+		Path: "@naira-project/dev",
+		PluginClaims: []PluginClaim{{
+			Plugin: "test-plugin",
+			Props:  map[string]string{},
+		}},
+	}, response)
+}
+
 func TestRunAllPluginsAsyncReturnsOperations(t *testing.T) {
 	opStore := operations.NewMemoryStore()
 	router := newTestRouter(catalog.NewMemoryStore(), opStore, map[string]pluginrun.Plugin{"seed": stubPlugin{}})


### PR DESCRIPTION
## Description

Node paths containing special characters were looked up using their URL-encoded value, causing valid nodes such as `@naira-project/dev` to return `404 Not Found`. This change decodes the path before lookup so encoded requests like `%40naira-project/dev` resolve to the correct catalog node.


<!-- What does this PR do? Why is it needed? Please link the related Issues-->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] 🏗️ Infrastructure / CI / Helm

## How Has This Been Tested?

<!-- Describe the tests that you ran. Need update when project progresses -->

- [x] `go test ./...` passes
- [ ] `helm lint` passes
- [ ] Manual testing via Docker Compose
- [ ] Manual testing on Kubernetes

## Checklist

- [ ] My code follows the project's coding standards ([AGENTS.md](AGENTS.md))
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally
- [ ] I have updated the documentation (if applicable)
- [ ] My changes generate no new warnings

<!-- Uncomment when AI was used for this PR
 Describe how and for what AI was used in this PR
## AI Usage



-->
<!-- Add screenshots for UI changes.

## Screenshots (if applicable)
-->
