### PR TITLE
build: deploy keycloak in declarative way

### DIFF
--- a/deploy/dev/stacks/core/infra/keycloak/keycloak.yaml
+++ b/deploy/dev/stacks/core/infra/keycloak/keycloak.yaml
@@ -1,3 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: keycloak
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/deploy/dev/stacks/core/infra/keycloak/kustomization.yaml
+++ b/deploy/dev/stacks/core/infra/keycloak/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: keycloak
+
+resources:
+  - keycloak.yaml
+  - secret.yaml
+
+configMapGenerator:
+  - name: keycloak-realm-import
+    files:
+      - naira-realm.json
+generatorOptions:
+  disableNameSuffixHash: true

--- a/deploy/dev/stacks/core/infra/keycloak/naira-realm.json
+++ b/deploy/dev/stacks/core/infra/keycloak/naira-realm.json
@@ -8,7 +8,7 @@
       "clientId": "naira-portal",
       "enabled": true,
       "publicClient": false,
-      "secret": "__KEYCLOAK_CLIENT_SECRET__",
+      "secret": "naira-local-dev-secret",
       "protocol": "openid-connect",
       "standardFlowEnabled": true,
       "directAccessGrantsEnabled": true,

--- a/deploy/dev/stacks/core/infra/keycloak/secret.yaml
+++ b/deploy/dev/stacks/core/infra/keycloak/secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keycloak-admin
+  namespace: keycloak
+type: Opaque
+stringData:
+  username: admin
+  password: admin

--- a/deploy/dev/stacks/core/infra/kubernetes/catalog.yaml
+++ b/deploy/dev/stacks/core/infra/kubernetes/catalog.yaml
@@ -279,12 +279,11 @@ spec:
             - name: PORT
               value: "8090"
             - name: KEYCLOAK_BASE_URL
-              value: __KEYCLOAK_BASE_URL__
-            # KEYCLOAK_REALM variable must be changed in tasks/keycloak.yml
+              value: http://keycloak.keycloak.svc.cluster.local:8080
             - name: KEYCLOAK_REALM
-              value: __KEYCLOAK_REALM__
+              value: naira
             - name: KEYCLOAK_ISSUER
-              value: __KEYCLOAK_ISSUER__
+              value: http://localhost:8080/realms/naira
             - name: PLUGIN_ADDRESSES
               value: "litellm=localhost:50051,mlflow=localhost:50052,depl-calls-svc=localhost:50053,depl-uses-litellm=localhost:50054,fluxcd=localhost:50055,openmetadata=localhost:50056,mcp-servers=localhost:50058"
           ports:

--- a/deploy/dev/stacks/core/infra/kubernetes/portal.yaml
+++ b/deploy/dev/stacks/core/infra/kubernetes/portal.yaml
@@ -27,9 +27,9 @@ spec:
             - name: BASE_DOMAINS_KEYCLOAK
               value: localhost
             - name: AUTH_SERVER_URL_KEYCLOAK
-              value: __AUTH_SERVER_URL_KEYCLOAK__
+              value: http://localhost:8080/realms/naira/protocol/openid-connect/auth
             - name: TOKEN_URL_KEYCLOAK
-              value: __TOKEN_URL_KEYCLOAK__
+              value: http://keycloak.keycloak.svc.cluster.local:8080/realms/naira/protocol/openid-connect/token
             - name: OIDC_CLIENT_ID_KEYCLOAK
               value: naira-portal
             - name: OIDC_CLIENT_SECRET_KEYCLOAK
@@ -59,6 +59,15 @@ spec:
             limits:
               cpu: 500m
               memory: 256Mi
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keycloak-client-secret
+  namespace: idp-system
+type: Opaque
+stringData:
+  client-secret: naira-local-dev-secret
 ---
 apiVersion: v1
 kind: Service

--- a/deploy/dev/stacks/core/tasks/catalog.yml
+++ b/deploy/dev/stacks/core/tasks/catalog.yml
@@ -9,10 +9,6 @@ vars:
   CATALOG_SERVICE: svc/catalog
   CATALOG_LOCAL_PORT: '8090'
   CATALOG_REMOTE_PORT: '8090'
-  KEYCLOAK_REMOTE_PORT: '8080'
-  KEYCLOAK_NAMESPACE: '{{.KEYCLOAK_NAMESPACE | default "keycloak"}}'
-  KEYCLOAK_REALM: '{{.KEYCLOAK_REALM | default "naira"}}'
-  KEYCLOAK_LOCAL_PORT: '{{.KEYCLOAK_LOCAL_PORT | default "8080"}}'
 
 tasks:
   image:build:
@@ -35,14 +31,7 @@ tasks:
     cmds:
       - task: image:load
       - task: :plugins:image:load
-      - task: :keycloak:deploy
-      - |
-        KEYCLOAK_BASE_URL="http://keycloak.{{.KEYCLOAK_NAMESPACE}}.svc.cluster.local:{{.KEYCLOAK_REMOTE_PORT}}"
-        KEYCLOAK_ISSUER="http://localhost:{{.KEYCLOAK_LOCAL_PORT}}/realms/{{.KEYCLOAK_REALM}}"
-        sed -e "s/__KEYCLOAK_REALM__/{{.KEYCLOAK_REALM}}/" \
-            -e "s|__KEYCLOAK_BASE_URL__|${KEYCLOAK_BASE_URL}|" \
-            -e "s|__KEYCLOAK_ISSUER__|${KEYCLOAK_ISSUER}|" \
-            {{.CATALOG_MANIFEST}} | kubectl apply -f -
+      - kubectl apply -f {{.CATALOG_MANIFEST}}
       - kubectl -n {{.CATALOG_NAMESPACE}} rollout status deploy/catalog --timeout=180s
       - kubectl -n {{.CATALOG_NAMESPACE}} get pods
 

--- a/deploy/dev/stacks/core/tasks/keycloak.yml
+++ b/deploy/dev/stacks/core/tasks/keycloak.yml
@@ -1,40 +1,23 @@
 version: '3'
 
 vars:
-  KEYCLOAK_MANIFEST: infra/kubernetes/keycloak.yaml
-  KEYCLOAK_REALM_IMPORT: infra/keycloak/naira-realm.json
+  KEYCLOAK_DIR: infra/keycloak
   KEYCLOAK_SERVICE: svc/keycloak
   KEYCLOAK_REMOTE_PORT: '8080'
   KEYCLOAK_NAMESPACE: '{{.KEYCLOAK_NAMESPACE | default "keycloak"}}'
-  KEYCLOAK_ADMIN_USER: '{{.KEYCLOAK_ADMIN_USER | default "admin"}}'
-  KEYCLOAK_ADMIN_PASSWORD: '{{.KEYCLOAK_ADMIN_PASSWORD | default "admin"}}'
 
 tasks:
   deploy:
-    desc: Deploy a local Keycloak to kind. The realm configuration is seeded from infra/keycloak/naira-realm.json
+    desc: Deploy a local Keycloak to kind from the declarative Kustomize overlay
     cmds:
       - task: apply
 
   apply:
     internal: true
     cmds:
-      - |
-        kubectl create namespace {{.KEYCLOAK_NAMESPACE}} --dry-run=client -o yaml | kubectl apply -f -
-        REALM_IMPORT_TMP="$(mktemp)"
-        trap 'rm -f "$REALM_IMPORT_TMP"' EXIT
-        sed -e "s|__KEYCLOAK_CLIENT_SECRET__|{{.KEYCLOAK_CLIENT_SECRET}}|" \
-            {{.KEYCLOAK_REALM_IMPORT}} > "$REALM_IMPORT_TMP"
-        kubectl create configmap keycloak-realm-import -n {{.KEYCLOAK_NAMESPACE}} \
-          --from-file=naira-realm.json="$REALM_IMPORT_TMP" \
-          --dry-run=client -o yaml | kubectl apply -f -
-        kubectl create secret generic keycloak-admin -n {{.KEYCLOAK_NAMESPACE}} \
-          --from-literal=username="{{.KEYCLOAK_ADMIN_USER}}" \
-          --from-literal=password="{{.KEYCLOAK_ADMIN_PASSWORD}}" \
-          --dry-run=client -o yaml | kubectl apply -f -
-        kubectl apply -f {{.KEYCLOAK_MANIFEST}}
-        kubectl -n {{.KEYCLOAK_NAMESPACE}} rollout restart deploy/keycloak
-        kubectl -n {{.KEYCLOAK_NAMESPACE}} rollout status deploy/keycloak --timeout=180s
-        kubectl -n {{.KEYCLOAK_NAMESPACE}} get pods
+      - kubectl apply -k {{.KEYCLOAK_DIR}}
+      - kubectl -n {{.KEYCLOAK_NAMESPACE}} rollout status deploy/keycloak --timeout=180s
+      - kubectl -n {{.KEYCLOAK_NAMESPACE}} get pods
 
   undeploy:
     desc: Remove the local Keycloak from kind

--- a/deploy/dev/stacks/core/tasks/portal.yml
+++ b/deploy/dev/stacks/core/tasks/portal.yml
@@ -9,11 +9,6 @@ vars:
   PORTAL_SERVICE: svc/portal
   PORTAL_LOCAL_PORT: '3000'
   PORTAL_REMOTE_PORT: '3000'
-  KEYCLOAK_REMOTE_PORT: '8080'
-  KEYCLOAK_NAMESPACE: '{{.KEYCLOAK_NAMESPACE | default "keycloak"}}'
-  KEYCLOAK_REALM: '{{.KEYCLOAK_REALM | default "naira"}}'
-  KEYCLOAK_LOCAL_PORT: '{{.KEYCLOAK_LOCAL_PORT | default "8080"}}'
-  KEYCLOAK_CLIENT_SECRET: '{{.KEYCLOAK_CLIENT_SECRET | default "naira-local-dev-secret"}}'
 
 tasks:
   image:build:
@@ -33,17 +28,7 @@ tasks:
     desc: Deploy the portal to kind
     cmds:
       - task: image:load
-      - task: :keycloak:deploy
-      - |
-        kubectl create namespace {{.PORTAL_NAMESPACE}} --dry-run=client -o yaml | kubectl apply -f -
-        kubectl create secret generic keycloak-client-secret -n {{.PORTAL_NAMESPACE}} \
-          --from-literal=client-secret="{{.KEYCLOAK_CLIENT_SECRET}}" \
-          --dry-run=client -o yaml | kubectl apply -f -
-        AUTH_SERVER_URL="http://localhost:{{.KEYCLOAK_LOCAL_PORT}}/realms/{{.KEYCLOAK_REALM}}/protocol/openid-connect/auth"
-        TOKEN_URL="http://keycloak.{{.KEYCLOAK_NAMESPACE}}.svc.cluster.local:{{.KEYCLOAK_REMOTE_PORT}}/realms/{{.KEYCLOAK_REALM}}/protocol/openid-connect/token"
-        sed -e "s|__AUTH_SERVER_URL_KEYCLOAK__|${AUTH_SERVER_URL}|" \
-            -e "s|__TOKEN_URL_KEYCLOAK__|${TOKEN_URL}|" \
-            {{.PORTAL_MANIFEST}} | kubectl apply -f -
+      - kubectl apply -f {{.PORTAL_MANIFEST}}
       - kubectl -n {{.PORTAL_NAMESPACE}} rollout status deploy/portal --timeout=180s
       - kubectl -n {{.PORTAL_NAMESPACE}} get pods
 
@@ -51,7 +36,6 @@ tasks:
     desc: Remove the portal from kind
     cmds:
       - kubectl delete -f {{.PORTAL_MANIFEST}} --ignore-not-found
-      - kubectl delete secret keycloak-client-secret -n {{.PORTAL_NAMESPACE}} --ignore-not-found
 
   port-forward:
     desc: Expose the portal on localhost:3000


### PR DESCRIPTION
## Description

Previously, deploying Keycloak through Flux wasn't possible. It was only possible by manually running tasks from taskfiles, which overwrote Keycloak related envs in catalog and portal.

With this PR, Keycloak deployment is possible with declarative files, which makes it possible to deploy the catalog and portal with Keycloak through Flux or Tilt.

<!-- What does this PR do? Why is it needed? Please link the related Issues-->

## Type of Change
- [x] 🏗️ Infrastructure / CI / Helm

## How Has This Been Tested?
- [x] Manual testing on Kubernetes
- [x] task core:deploy - works
- [x] tilt up - works