### PR TITLE
ci(ui): run biome and tsc checks in PR validation

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -70,8 +70,12 @@ jobs:
 
       - name: Run checks
         run: |
+          set -o pipefail
           npx tsc -b
-          npx biome ci --reporter=github .
+          # biome reports paths relative to this job's working-directory (ui/), but
+          # GitHub Actions resolves annotation `file=` paths relative to the repo
+          # root, so prefix them to make inline PR annotations line up correctly.
+          npx biome ci --reporter=github . | sed -E 's/(file=)/\1ui\//'
 
   # ── 4. Container build — catalog (build-only, no push on PRs) ─────────────
   container-build-catalog:

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -47,7 +47,31 @@ jobs:
       # revisit once the test suite reaches meaningful coverage.
       coverage-threshold: 0
 
-  # ── 3. Container build — catalog (build-only, no push on PRs) ─────────────
+  # ── 3. UI checks (TypeScript and Biome) ───────────────────────────────────
+  ui-check:
+    name: Check · UI
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ui
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: ui/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run checks
+        run: npm run check
+
+  # ── 4. Container build — catalog (build-only, no push on PRs) ─────────────
   container-build-catalog:
     name: Container Build · Catalog
     uses: naira-project/naira-github-workflows/.github/workflows/reusable-container-build-only.yml@9d11293b6fdfb550b5b8d43ae551639591bcf468
@@ -57,7 +81,7 @@ jobs:
       context: "."
       platforms: "linux/amd64,linux/arm64"
 
-  # ── 4. Container build — ui (build-only, no push on PRs) ──────────────────
+  # ── 5. Container build — ui (build-only, no push on PRs) ──────────────────
   container-build-ui:
     name: Container Build · UI
     uses: naira-project/naira-github-workflows/.github/workflows/reusable-container-build-only.yml@9d11293b6fdfb550b5b8d43ae551639591bcf468
@@ -70,7 +94,7 @@ jobs:
   # ── Gate: single required status check for branch protection ──────────────
   all-checks:
     name: All Checks Passed
-    needs: [pr-title, go-test, container-build-catalog, container-build-ui]
+    needs: [pr-title, go-test, ui-check, container-build-catalog, container-build-ui]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -79,6 +103,7 @@ jobs:
           RESULTS=(
             "${{ needs.pr-title.result }}"
             "${{ needs.go-test.result }}"
+            "${{ needs.ui-check.result }}"
             "${{ needs.container-build-catalog.result }}"
             "${{ needs.container-build-ui.result }}"
           )

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -69,7 +69,9 @@ jobs:
         run: npm ci
 
       - name: Run checks
-        run: npm run check
+        run: |
+          npx tsc -b
+          npx biome ci --reporter=github .
 
   # ── 4. Container build — catalog (build-only, no push on PRs) ─────────────
   container-build-catalog:

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -56,10 +56,10 @@ jobs:
         working-directory: ui
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
           cache: npm

--- a/ui/src/pages/Overview.tsx
+++ b/ui/src/pages/Overview.tsx
@@ -11,7 +11,6 @@ import { CATALOG_VIEWPOINTS } from '../config/viewpoints';
 export default function Overview() {
   const navigate = useNavigate();
   const [search, setSearch] = useState('');
-  debugger; // temporary: verifying PR-validation lint annotations, remove before merge
 
   const filteredViewpoints = CATALOG_VIEWPOINTS.filter((viewpoint) =>
     viewpoint.heading.toLowerCase().includes(search.toLowerCase()),

--- a/ui/src/pages/Overview.tsx
+++ b/ui/src/pages/Overview.tsx
@@ -11,6 +11,7 @@ import { CATALOG_VIEWPOINTS } from '../config/viewpoints';
 export default function Overview() {
   const navigate = useNavigate();
   const [search, setSearch] = useState('');
+  debugger; // temporary: verifying PR-validation lint annotations, remove before merge
 
   const filteredViewpoints = CATALOG_VIEWPOINTS.filter((viewpoint) =>
     viewpoint.heading.toLowerCase().includes(search.toLowerCase()),


### PR DESCRIPTION
## Description

Adds a `ui-check` job to `pr-validation.yml` that installs UI dependencies and runs `tsc -b` + `biome ci` (via the existing `npm run check` logic), wired into the `all-checks` gate so a lint or type-check failure blocks merge like `go-test` already does.

Biome runs with `--reporter=github`, so failures show up as inline annotations directly on the PR diff instead of only in the raw job log:

<img width="1028" height="181" alt="Screenshot 2026-09-02 at 16 20 42" src="https://github.com/user-attachments/assets/b70e9b41-fb34-458f-83e1-20b070ccd30d" />

One wrinkle: biome reports file paths relative to the job's `working-directory: ui`, but GitHub resolves annotation `file=` paths relative to the repo root — so unprefixed paths silently failed to line up with the diff. The `Run checks` step pipes biome's output through `sed` to prefix `ui/` onto each path (with `set -o pipefail` so a lint failure still fails the step).

Builds on the CI wiring already prototyped in #169 — the code-level lint/type fixes from that PR have since landed independently via #167, so this PR only adds the missing CI job itself, plus the GitHub-annotation reporter and path fix.


## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [x] 🏗️ Infrastructure / CI / Helm

## How Has This Been Tested?

- Verified directly against this PR's own CI runs: a deliberate `debugger` statement temporarily added to `Overview.tsx` caused `Check · UI` to fail with a correctly-placed inline annotation on the PR diff (screenshot above); removing it restored a green run.
- `cd ui && npm ci && npm run check` passes locally.

## Checklist

- [x] My code follows the project's coding standards ([AGENTS.md](AGENTS.md))
- [ ] I have added tests that prove my fix/feature works — N/A, this is a CI workflow change; verified live against this PR's own runs (see above)
- [x] New and existing unit tests pass locally
- [ ] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
